### PR TITLE
Update setOutputFormat method.

### DIFF
--- a/src/StanfordTagger/StanfordTagger.php
+++ b/src/StanfordTagger/StanfordTagger.php
@@ -55,7 +55,7 @@ abstract class StanfordTagger
         return $this->java;
     }
 
-    public function setOutputFormat(string $format)
+    public function setOutputFormat(int $format)
     {
         switch ($format)
         {


### PR DESCRIPTION
Update the parameter type from string to int on the setOutputFormat method. The constants for the output formats are integers, so having the parameter type as a string doesn't work.